### PR TITLE
Clean fakes option when purging orphans.

### DIFF
--- a/exporters.py
+++ b/exporters.py
@@ -139,6 +139,12 @@ class ExportBlenderCollection(Operator, ExportHelper):
         default=False
     )
 
+    clean_fakes: BoolProperty(
+        name="Clean Fake Users",
+        description="Set all items in the new scene to not use fake users before purging orphans.",
+        default=False
+    )
+
     @classmethod
     def poll(cls, context):
         return context.mode == 'OBJECT' # Because funky things happen when not in Object Mode
@@ -150,7 +156,8 @@ class ExportBlenderCollection(Operator, ExportHelper):
             "export_selected": True,
             "export_as_collection": True,
             "collection_name": context.selected_ids[0].name, #XXX Assumes only one collection is selected
-            "backlink": self.backlink
+            "backlink": self.backlink,
+            "clean_fakes": self.clean_fakes
         }
         if bpy.app.version > (2, 93, 0):
             export_settings["mark_asset"] = self.mark_asset

--- a/functions.py
+++ b/functions.py
@@ -70,12 +70,19 @@ def export_blend_objects(context, export_settings):
     if export_settings["export_selected"] and export_settings["export_as_collection"]:
         if export_settings["is_collection"] == False:
             export_collection = bpy.data.collections.new(export_settings["collection_name"])
+            if export_settings["clean_fakes"]:
+                for key in bpy.data.user_map():
+                    key.use_fake_user = False
         else:
             export_collection = bpy.data.collections[export_settings["collection_name"]]
         export_scene.collection.children.link(export_collection)
 
     # Add objects from list to scene
     for ob in objects:
+        if export_settings["clean_fakes"]:
+            for key in bpy.data.user_map():
+                key.use_fake_user = False
+
         export_scene.collection.objects.link(ob)
         if export_settings["export_selected"]:
             if export_settings["export_as_collection"] and export_settings["is_collection"] == False:


### PR DESCRIPTION
Just as an artist-friendly precaution I included an option to clean fake users flags on export so the dependency graph doesn't pull in unused items that depend on other items that depend on fake users. 

I haven't looked a ton at the node export code so this is just for the non-node exports but if this is relevant to nodes as well its a simple add.

I've tested this with collection and object exports and it seems to work fine.