### PR TITLE
Support exporting from edit mode

### DIFF
--- a/exporters.py
+++ b/exporters.py
@@ -11,12 +11,12 @@ Created by Jason van Gumster
     modify it under the terms of the GNU General Public License
     as published by the Free Software Foundation; either version 3
     of the License, or (at your option) any later version.
-   
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-   
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, see <https://www.gnu.org/licenses/>.
 
@@ -30,6 +30,7 @@ from bpy.types import Operator
 
 # Local imports
 from .functions import export_blend_objects, export_blend_nodes
+from .utilities import mode_toggle
 
 
 class ExportBlenderObjects(Operator, ExportHelper):
@@ -77,10 +78,6 @@ class ExportBlenderObjects(Operator, ExportHelper):
         default=False
     )
 
-    @classmethod
-    def poll(cls, context):
-        return context.mode == 'OBJECT' # Because funky things happen when not in Object Mode
-
     def draw(self, context):
         layout = self.layout
         col = layout.column()
@@ -104,13 +101,20 @@ class ExportBlenderObjects(Operator, ExportHelper):
             "collection_name": self.collection_name,
             "backlink": self.backlink
         }
+
         if bpy.app.version > (2, 93, 0):
             export_settings["mark_asset"] = self.mark_asset
         else:
             export_settings["mark_asset"] = False
 
-        return export_blend_objects(context, export_settings)
+        # switching to object mode prevents unexpected behavior
+        prev_mode = mode_toggle(context, 'OBJECT')
 
+        export_blend_objects(context, export_settings)
+
+        mode_toggle(context, prev_mode)
+
+        return {'FINISHED'}
 
 class ExportBlenderCollection(Operator, ExportHelper):
     """Export a selected collection to a separate .blend file"""
@@ -157,7 +161,14 @@ class ExportBlenderCollection(Operator, ExportHelper):
         else:
             export_settings["mark_asset"] = False
 
-        return export_blend_objects(context, export_settings)
+        # switching to object mode prevents unexpected behavior
+        prev_mode = mode_toggle(context, 'OBJECT')
+
+        export_blend_objects(context, export_settings)
+
+        mode_toggle(context, prev_mode)
+
+        return {'FINISHED'}
 
 
 class ExportBlenderNodes(Operator, ExportHelper):
@@ -236,4 +247,12 @@ class ExportBlenderNodes(Operator, ExportHelper):
             "group_name": self.group_name,
             "backlink": self.backlink
         }
-        return export_blend_nodes(context, export_settings)
+
+        # switching to object mode prevents unexpected behavior
+        prev_mode = mode_toggle(context, 'OBJECT')
+
+        export_blend_nodes(context, export_settings)
+
+        mode_toggle(context, prev_mode)
+
+        return {'FINISHED'}

--- a/functions.py
+++ b/functions.py
@@ -11,12 +11,12 @@ Created by Jason van Gumster
     modify it under the terms of the GNU General Public License
     as published by the Free Software Foundation; either version 3
     of the License, or (at your option) any later version.
-   
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-   
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, see <https://www.gnu.org/licenses/>.
 
@@ -118,8 +118,6 @@ def export_blend_objects(context, export_settings):
                     filename = linkob
                 )
 
-    return {'FINISHED'}
-
 
 def export_blend_nodes(context, export_settings):
     print("Exporting nodes to .blend...")
@@ -186,5 +184,3 @@ def export_blend_nodes(context, export_settings):
             nodetree_type = linked_nodegroup.type.title() + "NodeGroup"
         replacement_group = current_nodetree.nodes.new(nodetree_type)
         replacement_group.node_tree = linked_nodegroup
-
-    return {'FINISHED'}

--- a/utilities.py
+++ b/utilities.py
@@ -1,0 +1,16 @@
+import bpy
+
+def mode_toggle(context, switch_to):
+    prev_mode = context.mode
+    switch = {
+        'EDIT_MESH': bpy.ops.object.editmode_toggle,
+        'SCULPT': bpy.ops.sculpt.sculptmode_toggle,
+        'PAINT_VERTEX': bpy.ops.paint.vertex_paint_toggle,
+        'PAINT_WEIGHT': bpy.ops.paint.weight_paint_toggle,
+        'PAINT_TEXTURE': bpy.ops.paint.texture_paint_toggle
+    }
+    if prev_mode != 'OBJECT':
+        switch[prev_mode]()
+    elif switch_to != 'OBJECT':
+        switch[switch_to]()
+    return prev_mode


### PR DESCRIPTION
Instead of disabling the operator in non-object mode, this will switch it to object mode during execution and then revert back to whatever mode it was in. 